### PR TITLE
Clang-tidyの3行目のエラー対応

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,6 @@
 #include "schneider_model.hpp"
 
-int main() {
+auto main() -> int {
     omniboat::Schneider schneider;
     schneider.init();
     schneider.debug();
@@ -9,5 +9,4 @@ int main() {
         schneider.one_step();
         // wait(1);
     }
-    return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,4 +9,5 @@ int main() {
         schneider.one_step();
         // wait(1);
     }
+    return 0;
 }


### PR DESCRIPTION
src/main.cpp:3: [medium:warning] use a trailing return type for this function  [modernize-use-trailing-return-type]