### PR TITLE
2行目のエラーを直した。

### DIFF
--- a/include/schneider_model.hpp
+++ b/include/schneider_model.hpp
@@ -135,7 +135,6 @@ private:
      */
     void rotate();
 
-private:
     AnalogIn adcIn1;  // ジョイスティック
     AnalogIn adcIn2;  // ジョイスティック
     AnalogIn volume;


### PR DESCRIPTION
include/schneider_model.hpp:133: [high:error] redundant access specifier has the same accessibility as the previous access specifier  [readability-redundant-access-specifiers,-warnings-as-errors]