### PR TITLE
:boom: Ignore `cppcoreguidelines-init-variables`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,6 +7,7 @@ Checks: -*,
   modernize-*,
   performance-*,
   readability-*,
+  -cppcoreguidelines-init-variables,
 WarningsAsErrors: "*,-modernize-*"
 HeaderFilterRegex: ""
 # AnalyzeTemporaryDtors: false


### PR DESCRIPTION
#56 