### PR TITLE
deal with magic numbers in schneider_model.cpp

### DIFF
--- a/include/schneider_model.hpp
+++ b/include/schneider_model.hpp
@@ -33,6 +33,16 @@ constexpr int trial_num = 1000;
 constexpr float volumeThreshold = 0.5F;
 
 /**
+ * @brief ジョイスティックの下限値
+ */
+constexpr float joyEffectiveRangeMin = 0.4F;
+
+/**
+ * @brief volumeの下限値・上限値
+ */
+constexpr std::array<float, 2> volumeEffectiveRange = {0.4F, 0.7F};
+
+/**
  * @brief pulsewidthの小さいほうの値
  */
 constexpr int minorRotatePulsewidthUs = 550;
@@ -41,6 +51,11 @@ constexpr int minorRotatePulsewidthUs = 550;
  * @brief pulsewidthの大きいほうの値
  */
 constexpr int majorRotatePulsewidthUs = 2350;
+
+/**
+ * @brief 座標・姿勢の目標値と現在値の偏差の有効範囲の最小値 (それ未満は偏差0とみなす)
+ */
+constexpr float diffEffectiveRangeMin = 0.001F;
 
 /**
  * @brief モータへの出力を計算するクラス

--- a/include/schneider_model.hpp
+++ b/include/schneider_model.hpp
@@ -35,12 +35,12 @@ constexpr float volumeThreshold = 0.5F;
 /**
  * @brief ジョイスティックの下限値
  */
-constexpr float joyEffectiveRangeMin = 0.4F;
+constexpr float joyThreshold = 0.4F;
 
 /**
  * @brief volumeの下限値・上限値
  */
-constexpr std::array<float, 2> volumeEffectiveRange = {0.4F, 0.7F};
+constexpr std::pair<float, float> volumeIneffectiveRange = {0.4F, 0.7F};
 
 /**
  * @brief pulsewidthの小さいほうの値
@@ -55,7 +55,7 @@ constexpr int majorRotatePulsewidthUs = 2350;
 /**
  * @brief 座標・姿勢の目標値と現在値の偏差の有効範囲の最小値 (それ未満は偏差0とみなす)
  */
-constexpr float diffEffectiveRangeMin = 0.001F;
+constexpr float diffThreshold = 0.001F;
 
 /**
  * @brief モータへの出力を計算するクラス

--- a/src/schneider_model.cpp
+++ b/src/schneider_model.cpp
@@ -74,10 +74,15 @@ void Schneider::one_step() {
     q[0] = 0;
     q[1] = 0;
 
-    if (abs(x_d[0]) > 0.4F || abs(x_d[1]) > 0.4F) {
+    const bool joyEffective
+        = abs(x_d[0]) > joyEffectiveRangeMin || abs(x_d[1]) > joyEffectiveRangeMin;
+    const bool volumeEffective
+        = volumeEffectiveRange[0] < volume_ && volume_ < volumeEffectiveRange[1];
+
+    if (joyEffective) {
         cal_q();
         set_q();
-    } else if (volume_ < 0.4F || 0.7F < volume_) {
+    } else if (volumeEffective) {
         rotate();
         phi = 0;
     } else {
@@ -139,7 +144,7 @@ void Schneider::cal_q() {
         state_equation();
 
         double diff = pow(x[0] - x_d[0], 2) + pow(x[1] - x_d[1], 2) + pow(x[2] - x_d[2], 2);
-        if (diff < 1e-3) {
+        if (diff < diffEffectiveRangeMin) {
             break;
         }
 
@@ -166,10 +171,10 @@ inline void Schneider::state_equation() {
 
 void Schneider::set_q() {
     using std::abs;
-    if (abs(this->q[0] <= 0.4F)) {
+    if (abs(this->q[0] <= joyEffectiveRangeMin)) {
         this->q[0] = 0;
     }
-    if (abs(this->q[1] <= 0.4F)) {
+    if (abs(this->q[1] <= joyEffectiveRangeMin)) {
         this->q[1] = 0;
     }
     this->fet_1 = this->q[0];

--- a/src/schneider_model.cpp
+++ b/src/schneider_model.cpp
@@ -74,10 +74,9 @@ void Schneider::one_step() {
     q[0] = 0;
     q[1] = 0;
 
-    const bool joyEffective
-        = abs(x_d[0]) > joyEffectiveRangeMin || abs(x_d[1]) > joyEffectiveRangeMin;
+    const bool joyEffective = abs(x_d[0]) > joyThreshold || abs(x_d[1]) > joyThreshold;
     const bool volumeEffective
-        = volumeEffectiveRange[0] < volume_ && volume_ < volumeEffectiveRange[1];
+        = volume_ < volumeIneffectiveRange.first || volumeIneffectiveRange.second < volume_;
 
     if (joyEffective) {
         cal_q();
@@ -144,7 +143,7 @@ void Schneider::cal_q() {
         state_equation();
 
         double diff = pow(x[0] - x_d[0], 2) + pow(x[1] - x_d[1], 2) + pow(x[2] - x_d[2], 2);
-        if (diff < diffEffectiveRangeMin) {
+        if (diff < diffThreshold) {
             break;
         }
 
@@ -171,10 +170,10 @@ inline void Schneider::state_equation() {
 
 void Schneider::set_q() {
     using std::abs;
-    if (abs(this->q[0] <= joyEffectiveRangeMin)) {
+    if (abs(this->q[0] <= joyThreshold)) {
         this->q[0] = 0;
     }
-    if (abs(this->q[1] <= joyEffectiveRangeMin)) {
+    if (abs(this->q[1] <= joyThreshold)) {
         this->q[1] = 0;
     }
     this->fet_1 = this->q[0];


### PR DESCRIPTION
solved errors on clang-tidy:
- `src/schneider_model.cpp:80: [high:error] 0.4F is a magic number; consider replacing it with a named constant  [cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers,-warnings-as-errors]`
- `src/schneider_model.cpp:80: [high:error] 0.7F is a magic number; consider replacing it with a named constant  [cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers,-warnings-as-errors]`
- `src/schneider_model.cpp:142: [high:error] 1e-3 is a magic number; consider replacing it with a named constant  [cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers,-warnings-as-errors]`
- `src/schneider_model.cpp:169: [high:error] 0.4F is a magic number; consider replacing it with a named constant  [cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers,-warnings-as-errors]`
- `src/schneider_model.cpp:172: [high:error] 0.4F is a magic number; consider replacing it with a named constant  [cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers,-warnings-as-errors]`