### PR TITLE
:fire: `cppcoreguidelines-pro-type-vararg`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,6 +8,7 @@ Checks: -*,
   performance-*,
   readability-*,
   -cppcoreguidelines-init-variables,
+  -cppcoreguidelines-pro-type-vararg,
 WarningsAsErrors: "*,-modernize-*"
 HeaderFilterRegex: ""
 # AnalyzeTemporaryDtors: false


### PR DESCRIPTION
#56 