### PR TITLE
limited the scope of constexpr variables in the namespace `schneider_model`

### DIFF
--- a/include/schneider_model.hpp
+++ b/include/schneider_model.hpp
@@ -7,10 +7,12 @@
 
 #include "MPU6050.h"
 
-constexpr float schneider_PI = 3.141592653589;
-
 namespace omniboat {
 
+/**
+ * @brief π
+ */
+constexpr float schneider_PI = 3.1415927F;
 /**
  * @brief z軸周りの慣性モーメント
  * @note もっと正確な値の方がいいかも
@@ -19,58 +21,7 @@ constexpr float I = 1;  // NOLINT: FIXME
 /**
  * @brief ステップ幅
  */
-constexpr float e = 0.01;  // NOLINT: FIXME
-constexpr float a = 0.1;   // NOLINT: FIXME
-
-/**
- * @brief 試行回数
- */
-constexpr int trial_num = 1000;
-
-/**
- * @brief volumeの閾値
- */
-constexpr float volumeThreshold = 0.5F;
-
-/**
- * @brief ジョイスティックの下限値
- */
-constexpr float joyThreshold = 0.4F;
-
-/**
- * @brief ジョイスティックの中央値
- */
-constexpr float joyCenter = 0.5F;
-
-/**
- * @brief volumeの下限値・上限値
- */
-constexpr std::pair<float, float> volumeIneffectiveRange = {0.4F, 0.7F};
-
-/**
- * @brief pulsewidthの小さいほうの値
- */
-constexpr int minorRotatePulsewidthUs = 550;
-
-/**
- * @brief pulsewidthの大きいほうの値
- */
-constexpr int majorRotatePulsewidthUs = 2350;
-
-/**
- * @brief 座標・姿勢の目標値と現在値の偏差の有効範囲の最小値 (それ未満は偏差0とみなす)
- */
-constexpr float diffThreshold = 0.001F;
-
-/**
- * @brief サーボのPWM周期
- */
-constexpr int pwmPeriodMs = 20;
-
-/**
- * @brief DCモータ用FETへのPWM出力(duty比)
- */
-constexpr float fetDuty = 0.5F;
+constexpr float a = 0.1;  // NOLINT: FIXME
 
 /**
  * @brief モータへの出力を計算するクラス

--- a/include/schneider_model.hpp
+++ b/include/schneider_model.hpp
@@ -10,20 +10,6 @@
 namespace omniboat {
 
 /**
- * @brief π
- */
-constexpr float schneider_PI = 3.1415927F;
-/**
- * @brief z軸周りの慣性モーメント
- * @note もっと正確な値の方がいいかも
- */
-constexpr float I = 1;  // NOLINT: FIXME
-/**
- * @brief ステップ幅
- */
-constexpr float a = 0.1;  // NOLINT: FIXME
-
-/**
  * @brief モータへの出力を計算するクラス
  */
 class Schneider {

--- a/src/schneider_model.cpp
+++ b/src/schneider_model.cpp
@@ -168,7 +168,7 @@ auto Schneider::cal_q(const std::array<float, 3>& joy) -> void {
     }
 
     led(2);
-    for (int i = 0; i < trial_num; i++) {
+    for (size_t i = 0; i < trial_num; i++) {
         // 目標値との差の2乗ノルム(diff)の実効下限値
         constexpr float diff_min = 0.001F;
 

--- a/src/schneider_model.cpp
+++ b/src/schneider_model.cpp
@@ -10,6 +10,20 @@
 
 namespace omniboat {
 
+/**
+ * @brief π
+ */
+constexpr float schneider_PI = 3.1415927F;
+/**
+ * @brief z軸周りの慣性モーメント
+ * @note もっと正確な値の方がいいかも
+ */
+constexpr float I = 1.0F;  // NOLINT: FIXME
+/**
+ * @brief ステップ幅
+ */
+constexpr float a = 0.1F;  // NOLINT: FIXME
+
 Schneider::Schneider() :
     t_jacobianmatrix(),
     q(),
@@ -26,7 +40,7 @@ Schneider::Schneider() :
     led2(PA_3),
     led3(PA_4),
     pc(USBTX, USBRX) {
-    constexpr auto servo_pwm_period_ms = 20;
+    constexpr auto servo_pwm_period_ms = 20U;
 
     this->led(1);
     this->led(2);
@@ -64,7 +78,7 @@ void Schneider::one_step() {
     using std::abs;
     // ジョイスティックの値の実効下限値
     constexpr auto joy_min = 0.4F;
-    // つまみの値の実効範囲 (x < volume_under || volume_over < x)
+    // つまみの値の実効範囲 (x < volume_under || volume_over < x で有効)
     constexpr auto volume_under = 0.4F;
     constexpr auto volume_over = 0.7F;
 
@@ -140,7 +154,7 @@ inline void Schneider::cal_tjacob() {
 auto Schneider::cal_q(const std::array<float, 3>& joy) -> void {
     using std::pow;
     // ステップ幅
-    constexpr auto e = 0.01F;
+    constexpr auto e = 0.01F;  // NOLINT: FIXME
     // 試行回数
     constexpr auto trial_num = 1000;
 
@@ -196,10 +210,10 @@ void Schneider::set_q(const std::array<float, 3>& gyro) {
     // 系への入力値の実効下限値
     constexpr float input_min = 0.4F;
 
-    if (abs(this->q[0]) <= input_min) {
+    if (abs(this->q[0] <= input_min)) {
         this->q[0] = 0;
     }
-    if (abs(this->q[1]) <= input_min) {
+    if (abs(this->q[1] <= input_min)) {
         this->q[1] = 0;
     }
     this->fet_1 = this->q[0];
@@ -232,8 +246,8 @@ void Schneider::rotate(const float& volume_value) {
     // volumeのしきい値
     constexpr auto volume_threshold = 0.5F;
     // サーボモータ出力値(pulse width)
-    constexpr auto minor_rotate_pulse_width_us = 550;
-    constexpr auto major_rotate_pulse_width_us = 2350;
+    constexpr auto minor_rotate_pulsewidth_us = 550;
+    constexpr auto major_rotate_pulsewidth_us = 2350;
     // DCモータ出力値(duty比)
     constexpr auto fet_duty = 0.5F;
 
@@ -241,11 +255,11 @@ void Schneider::rotate(const float& volume_value) {
     this->fet_2 = fet_duty;
     // ifとelseで内容が同じだといわれたがそんなことない
     if (volume_value < volume_threshold) {
-        this->servo_1.pulsewidth_us(minor_rotate_pulse_width_us);
-        this->servo_2.pulsewidth_us(major_rotate_pulse_width_us);
+        this->servo_1.pulsewidth_us(minor_rotate_pulsewidth_us);
+        this->servo_2.pulsewidth_us(major_rotate_pulsewidth_us);
     } else {
-        this->servo_2.pulsewidth_us(minor_rotate_pulse_width_us);
-        this->servo_1.pulsewidth_us(major_rotate_pulse_width_us);
+        this->servo_2.pulsewidth_us(minor_rotate_pulsewidth_us);
+        this->servo_1.pulsewidth_us(major_rotate_pulsewidth_us);
     }
 }
 

--- a/src/schneider_model.cpp
+++ b/src/schneider_model.cpp
@@ -156,7 +156,7 @@ auto Schneider::cal_q(const std::array<float, 3>& joy) -> void {
     led(2);
     for (int i = 0; i < trial_num; i++) {
         // 目標値との差の2乗ノルム(diff)の実効下限値
-        constexpr auto diff_min = 0.001;
+        constexpr auto diff_min = 0.001F;
 
         this->state_equation();
 

--- a/src/schneider_model.cpp
+++ b/src/schneider_model.cpp
@@ -40,7 +40,7 @@ Schneider::Schneider() :
     led2(PA_3),
     led3(PA_4),
     pc(USBTX, USBRX) {
-    constexpr auto servo_pwm_period_ms = 20U;
+    constexpr uint8_t servo_pwm_period_ms = 20U;
 
     this->led(1);
     this->led(2);
@@ -77,10 +77,10 @@ void Schneider::init() {
 void Schneider::one_step() {
     using std::abs;
     // ジョイスティックの値の実効下限値
-    constexpr auto joy_min = 0.4F;
+    constexpr float joy_min = 0.4F;
     // つまみの値の実効範囲 (x < volume_under || volume_over < x で有効)
-    constexpr auto volume_under = 0.4F;
-    constexpr auto volume_over = 0.7F;
+    constexpr float volume_under = 0.4F;
+    constexpr float volume_over = 0.7F;
 
     this->led(3);
 
@@ -123,7 +123,7 @@ void Schneider::debug() {
 
 auto Schneider::read_joy() -> std::array<float, 3> {
     // ジョイスティックの中心値
-    constexpr auto joy_center = 0.5F;
+    constexpr float joy_center = 0.5F;
 
     const auto joy_x = this->adcIn1.read();
     const auto joy_y = this->adcIn2.read();
@@ -154,9 +154,9 @@ inline void Schneider::cal_tjacob() {
 auto Schneider::cal_q(const std::array<float, 3>& joy) -> void {
     using std::pow;
     // ステップ幅
-    constexpr auto e = 0.01F;  // NOLINT: FIXME
+    constexpr float e = 0.01F;  // NOLINT: FIXME
     // 試行回数
-    constexpr auto trial_num = 1000;
+    constexpr size_t trial_num = 1000U;
 
     // 初期値
     const float coef = (joy[0] >= 0 && joy[1] >= 0)  ? 1
@@ -170,7 +170,7 @@ auto Schneider::cal_q(const std::array<float, 3>& joy) -> void {
     led(2);
     for (int i = 0; i < trial_num; i++) {
         // 目標値との差の2乗ノルム(diff)の実効下限値
-        constexpr auto diff_min = 0.001F;
+        constexpr float diff_min = 0.001F;
 
         this->state_equation();
 
@@ -244,12 +244,12 @@ void Schneider::set_q(const std::array<float, 3>& gyro) {
 
 void Schneider::rotate(const float& volume_value) {
     // volumeのしきい値
-    constexpr auto volume_threshold = 0.5F;
+    constexpr float volume_threshold = 0.5F;
     // サーボモータ出力値(pulse width)
-    constexpr auto minor_rotate_pulsewidth_us = 550;
-    constexpr auto major_rotate_pulsewidth_us = 2350;
+    constexpr uint16_t minor_rotate_pulsewidth_us = 550U;
+    constexpr uint16_t major_rotate_pulsewidth_us = 2350U;
     // DCモータ出力値(duty比)
-    constexpr auto fet_duty = 0.5F;
+    constexpr float fet_duty = 0.5F;
 
     this->fet_1 = fet_duty;
     this->fet_2 = fet_duty;


### PR DESCRIPTION
`I`と`a`は未対応