### PR TITLE
PlatformIOのビルドキャッシュ

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Cache
+        uses: actions/cache@v4
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+            .pio/cache
+          key: ${{ runner.os }}-pio
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,6 +10,7 @@
 
 [platformio]
 default_envs = nucleo_f303k8
+build_cache_dir = .pio/cache
 
 [env]
 platform = ststm32


### PR DESCRIPTION
とりあえずCIではmainブランチでのみ使うように